### PR TITLE
Update intervention image provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require": {
     "php": ">=5.4",
     "composer/installers": "~1.0",
-    "intervention/image": "2.0.14"
+    "intervention/image": "~2.1.1"
   },
   "minimum-stability": "dev"
 }


### PR DESCRIPTION
~2.1 supports Laravel 5 with Intervention\Image\ImageServiceProviderLaravel5 as service provider