### PR TITLE
Add data-id to Original image

### DIFF
--- a/Resources/views/admin/grid/partials/content.blade.php
+++ b/Resources/views/admin/grid/partials/content.blade.php
@@ -72,7 +72,7 @@
                                         </li>
                                         <?php endforeach; ?>
                                         <li class="divider"></li>
-                                        <li data-file="{{ $file->path }}" class="jsInsertImage">
+                                        <li data-file="{{ $file->path }}" data-id="{{ $file->id }}" class="jsInsertImage">
                                             <a href="">Original</a>
                                         </li>
                                     </ul>


### PR DESCRIPTION
On testing, one of my users was seemingly unable to add media to a blog post. Turns out, they were clicking the "Original" size to insert, and the file's id was not being passed to the API.