### PR TITLE
Fix early redirect when uploading multiple files

### DIFF
--- a/Assets/js/init-dropzone.js
+++ b/Assets/js/init-dropzone.js
@@ -6,7 +6,7 @@ $( document ).ready(function() {
         maxFilesize: maxFilesize,
         acceptedFiles : acceptedFiles
     });
-    myDropzone.on("success", function(file, http) {
+    myDropzone.on("queuecomplete", function(file, http) {
         window.setTimeout(function(){
             location.reload();
         }, 1000);


### PR DESCRIPTION
I had the case where I needed to upload 20+ files. Some files were uploaded others not. 
The others failed due to the location.reload() function triggered on the first success emit from a first successful upload.

It seems by using the queuecomplete event it works in both cases: 
- uploading 1 file
- uploading 20 files