### PR TITLE
Allow media zone to have multiple words, separated by underscore.

### DIFF
--- a/Resources/views/admin/fields/file-link-multiple.blade.php
+++ b/Resources/views/admin/fields/file-link-multiple.blade.php
@@ -51,7 +51,7 @@
             });
         }
     </script>
-    {!! Form::label($zone, ucfirst($zone) . ':') !!}
+    {!! Form::label($zone, ucwords(str_replace('_', ' ', $zone)) . ':') !!}
     <div class="clearfix"></div>
     <?php $url = route('media.grid.select') ?>
     <a class="btn btn-primary btn-upload" onclick="window.open('{!! $url !!}', '_blank', 'menubar=no,status=no,toolbar=no,scrollbars=yes,height=500,width=1000');"><i class="fa fa-upload"></i>

--- a/Resources/views/admin/fields/file-link.blade.php
+++ b/Resources/views/admin/fields/file-link.blade.php
@@ -42,7 +42,7 @@
             });
         }
     </script>
-    {!! Form::label($zone, ucfirst($zone) . ':') !!}
+    {!! Form::label($zone, ucwords(str_replace('_', ' ', $zone)) . ':') !!}
     <div class="clearfix"></div>
 
     <?php $url = route('media.grid.select') ?>


### PR DESCRIPTION
This will ONLY work with an underscore, as PHP variable names cannot
contain dashes or periods. StudlyCaps and camelCase are likewise not
working because seprating them would require stupidly complex Regex.
Someone else can feel free to attept it, if they so wish.

Signed-off-by: Micheal Mand <micheal@kmdwebdesigns.com>