### PR TITLE
Allow dev to choose which size thumbnail to show for previews

### DIFF
--- a/Resources/views/admin/fields/file-link-multiple.blade.php
+++ b/Resources/views/admin/fields/file-link-multiple.blade.php
@@ -75,7 +75,7 @@
         <?php if (isset($$zoneVar)): ?>
             <?php foreach ($$zoneVar as $file): ?>
                 <figure>
-                    <img src="{{ Imagy::getThumbnail($file->path, 'mediumThumb') }}" alt=""/>
+                    <img src="{{ Imagy::getThumbnail($file->path, (isset($thumbnailSize) ? $thumbnailSize : 'mediumThumb')) }}" alt="{{ $file->alt_attribute }}"/>
                     <a class="jsRemoveLink" href="#" data-id="{{ $file->pivot->id }}">
                         <i class="fa fa-times-circle removeIcon"></i>
                     </a>

--- a/Resources/views/admin/fields/file-link.blade.php
+++ b/Resources/views/admin/fields/file-link.blade.php
@@ -66,7 +66,7 @@
     <figure class="jsThumbnailImageWrapper">
         <?php if (isset(${$zone}->path)): ?>
             <?php if (${$zone}->isImage()): ?>
-                <img src="{{ Imagy::getThumbnail(${$zone}->path, 'mediumThumb') }}" alt=""/>
+                <img src="{{ Imagy::getThumbnail(${$zone}->path, (isset($thumbnailSize) ? $thumbnailSize : 'mediumThumb')) }}" alt="{{ ${$zone}->alt_attribute }}"/>
             <?php else: ?>
                 <i class="fa fa-file" style="font-size: 50px;"></i>
             <?php endif; ?>

--- a/Resources/views/admin/fields/file-link.blade.php
+++ b/Resources/views/admin/fields/file-link.blade.php
@@ -1,59 +1,59 @@
+<style>
+    figure.jsThumbnailImageWrapper {
+        position: relative;
+        display: inline-block;
+        background-color: #fff;
+        border: 1px solid #eee;
+        padding: 3px;
+        border-radius: 3px;
+        margin-top: 20px;
+    }
+    figure.jsThumbnailImageWrapper i.removeIcon {
+        position: absolute;
+        top:-10px;
+        right:-10px;
+        color: #f56954;
+        font-size: 2em;
+        background: white;
+        border-radius: 20px;
+        height: 25px;
+    }
+</style>
+<script>
+    if (typeof window.openMediaWindow === 'undefined') {
+        window.mediaZone = '';
+        window.openMediaWindow = function (event, zone) {
+            window.mediaZone = zone;
+            window.zoneWrapper = $(event.currentTarget).siblings('.jsThumbnailImageWrapper');
+            window.open('{!! route('media.grid.select') !!}', '_blank', 'menubar=no,status=no,toolbar=no,scrollbars=yes,height=500,width=1000');
+        };
+    }
+    if (typeof window.includeMedia === 'undefined') {
+        window.includeMedia = function (mediaId) {
+            $.ajax({
+                type: 'POST',
+                url: '{{ route('api.media.link') }}',
+                data: {
+                    'mediaId': mediaId,
+                    '_token': '{{ csrf_token() }}',
+                    'entityClass': '{{ $entityClass }}',
+                    'entityId': '{{ $entityId }}',
+                    'zone': window.mediaZone
+                },
+                success: function (data) {
+                    var html = '<img src="' + data.result.path + '" alt=""/>' +
+                            '<a class="jsRemoveSimpleLink" href="#" data-id="' + data.result.imageableId + '">' +
+                            '<i class="fa fa-times-circle removeIcon"></i>' +
+                            '</a>';
+                    window.zoneWrapper.append(html).fadeIn('slow', function() {
+                        toggleButton($(this));
+                    });
+                }
+            });
+        };
+    }
+</script>
 <div class="form-group">
-    <style>
-        figure.jsThumbnailImageWrapper {
-            position: relative;
-            display: inline-block;
-            background-color: #fff;
-            border: 1px solid #eee;
-            padding: 3px;
-            border-radius: 3px;
-            margin-top: 20px;
-        }
-        figure.jsThumbnailImageWrapper i.removeIcon {
-            position: absolute;
-            top:-10px;
-            right:-10px;
-            color: #f56954;
-            font-size: 2em;
-            background: white;
-            border-radius: 20px;
-            height: 25px;
-        }
-    </style>
-    <script>
-        if (typeof window.openMediaWindow === 'undefined') {
-            window.mediaZone = '';
-            window.openMediaWindow = function (event, zone) {
-                window.mediaZone = zone;
-                window.zoneWrapper = $(event.currentTarget).siblings('.jsThumbnailImageWrapper');
-                window.open('{!! route('media.grid.select') !!}', '_blank', 'menubar=no,status=no,toolbar=no,scrollbars=yes,height=500,width=1000');
-            };
-        }
-        if (typeof window.includeMedia === 'undefined') {
-            window.includeMedia = function (mediaId) {
-                $.ajax({
-                    type: 'POST',
-                    url: '{{ route('api.media.link') }}',
-                    data: {
-                        'mediaId': mediaId,
-                        '_token': '{{ csrf_token() }}',
-                        'entityClass': '{{ $entityClass }}',
-                        'entityId': '{{ $entityId }}',
-                        'zone': window.mediaZone
-                    },
-                    success: function (data) {
-                        var html = '<img src="' + data.result.path + '" alt=""/>' +
-                                '<a class="jsRemoveSimpleLink" href="#" data-id="' + data.result.imageableId + '">' +
-                                '<i class="fa fa-times-circle removeIcon"></i>' +
-                                '</a>';
-                        window.zoneWrapper.append(html).fadeIn('slow', function() {
-                            toggleButton($(this));
-                        });
-                    }
-                });
-            };
-        }
-    </script>
     {!! Form::label($zone, ucwords(str_replace('_', ' ', $zone)) . ':') !!}
     <div class="clearfix"></div>
 


### PR DESCRIPTION
If the thumbnail is placed in a smaller column (or the client has a smaller screen size) the thumbnail and remove button overflow the element (and depending on the theme's styles, are hidden). This allows the developer to chose which thumbnail size to use.

The first commit really has nothing to do with this feature, but it does make both file-link and file-link-multiple similar in structure. Based on commit 5ee422672488c1b481afae142a3649a68b99818f.