### PR TITLE
Modified API and media fields to enable video preview on link creation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 vendor/
 composer.lock
 Modules/
+/.project

--- a/Http/Controllers/Api/MediaController.php
+++ b/Http/Controllers/Api/MediaController.php
@@ -98,7 +98,7 @@ class MediaController extends Controller
             ->first();
         $file = $this->file->find($imageable->file_id);
         
-        if ($file->mimetype == 'video/mp4' || $file->mimetype == 'video/ogv' || $file->mimetype == 'video/webm') {
+        if (strpos($file->mimetype, 'video') !== 0) {
             $thumbnailPath = $file->path->getRelativeUrl();
             $mediaType = 'video';
         } else {

--- a/Http/Controllers/Api/MediaController.php
+++ b/Http/Controllers/Api/MediaController.php
@@ -83,12 +83,14 @@ class MediaController extends Controller
         $mediaId = $request->get('mediaId');
         $entityClass = $request->get('entityClass');
         $entityId = $request->get('entityId');
+        $order = $request->get('order');
         
         $entity = $entityClass::find($entityId);
         $zone = $request->get('zone');
         $entity->files()->attach($mediaId, [
             'imageable_type' => $entityClass,
-            'zone' => $zone
+            'zone' => $zone, 
+            'order' => $order
         ]);
         $imageable = DB::table('media__imageables')->whereFileId($mediaId)
             ->whereZone($zone)

--- a/Http/Controllers/Api/MediaController.php
+++ b/Http/Controllers/Api/MediaController.php
@@ -1,4 +1,6 @@
-<?php namespace Modules\Media\Http\Controllers\Api;
+<?php
+
+namespace Modules\Media\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -14,15 +16,21 @@ use Modules\Media\Services\FileService;
 
 class MediaController extends Controller
 {
+
     /**
+     *
      * @var FileService
      */
     private $fileService;
+
     /**
+     *
      * @var FileRepository
      */
     private $file;
+
     /**
+     *
      * @var Imagy
      */
     private $imagy;
@@ -37,80 +45,100 @@ class MediaController extends Controller
     public function all()
     {
         $files = $this->file->all();
-
+        
         return [
             'count' => $files->count(),
-            'data' => $files,
+            'data' => $files
         ];
     }
 
     /**
      * Store a newly created resource in storage.
-     * @param  UploadMediaRequest $request
+     * 
+     * @param UploadMediaRequest $request            
      * @return Response
      */
     public function store(UploadMediaRequest $request)
     {
         $savedFile = $this->fileService->store($request->file('file'));
-
+        
         if (is_string($savedFile)) {
-            return Response::json(['error' => $savedFile], 409);
+            return Response::json([
+                'error' => $savedFile
+            ], 409);
         }
-
+        
         event(new FileWasUploaded($savedFile));
-
+        
         return Response::json($savedFile->toArray());
     }
 
     /**
      * Link the given entity with a media file
-     * @param Request $request
+     * 
+     * @param Request $request            
      */
     public function linkMedia(Request $request)
     {
         $mediaId = $request->get('mediaId');
         $entityClass = $request->get('entityClass');
         $entityId = $request->get('entityId');
-
+        
         $entity = $entityClass::find($entityId);
         $zone = $request->get('zone');
-        $entity->files()->attach($mediaId, ['imageable_type' => $entityClass, 'zone' => $zone]);
-        $imageable = DB::table('media__imageables')->whereFileId($mediaId)->whereZone($zone)->whereImageableType($entityClass)->first();
+        $entity->files()->attach($mediaId, [
+            'imageable_type' => $entityClass,
+            'zone' => $zone
+        ]);
+        $imageable = DB::table('media__imageables')->whereFileId($mediaId)
+            ->whereZone($zone)
+            ->whereImageableType($entityClass)
+            ->first();
         $file = $this->file->find($imageable->file_id);
-                
+        
         if ($file->mimetype == 'video/mp4' || $file->mimetype == 'video/ogv' || $file->mimetype == 'video/webm') {
-        	$thumbnailPath = $file->path->getRelativeUrl();
-        	$mediaType = 'video';
+            $thumbnailPath = $file->path->getRelativeUrl();
+            $mediaType = 'video';
+        } else {
+            $thumbnailPath = $this->imagy->getThumbnail($file->path, 'mediumThumb');
+            $mediaType = 'image';
         }
-        else {
-        	$thumbnailPath = $this->imagy->getThumbnail($file->path, 'mediumThumb');
-        	$mediaType = 'image';
-        }
-
+        
         event(new FileWasLinked($file, $entity));
-
+        
         return Response::json([
             'error' => false,
             'message' => 'The link has been added.',
-            'result' => ['path' => $thumbnailPath, 'imageableId' => $imageable->id, 'mediaType' => $mediaType]
+            'result' => [
+                'path' => $thumbnailPath,
+                'imageableId' => $imageable->id,
+                'mediaType' => $mediaType
+            ]
         ]);
     }
 
     /**
      * Remove the record in the media__imageables table for the given id
-     * @param Request $request
+     * 
+     * @param Request $request            
      */
     public function unlinkMedia(Request $request)
     {
         $imageableId = $request->get('imageableId');
         $deleted = DB::table('media__imageables')->whereId($imageableId)->delete();
         if (! $deleted) {
-            return Response::json(['error' => true, 'message' => 'The file was not found.']);
+            return Response::json([
+                'error' => true,
+                'message' => 'The file was not found.'
+            ]);
         }
-
+        
         event(new FileWasUnlinked($imageableId));
-
-        return Response::json(['error' => false, 'message' => 'The link has been removed.']);
+        
+        return Response::json([
+            'error' => false,
+            'message' => 'The link has been removed.'
+        ]);
     }
 
     /**

--- a/Resources/views/admin/fields/file-link-multiple.blade.php
+++ b/Resources/views/admin/fields/file-link-multiple.blade.php
@@ -57,17 +57,16 @@
                     'order': $('.jsThumbnailImageWrapper figure').size() + 1
                 },
                 success: function (data) {
-                	if (data.result.mediaType === 'image') {
+                    if (data.result.mediaType === 'image') {
                         var mediaPlaceholder = '<img src="' + data.result.path + '" alt=""/>';
-	                    
                     }
                     else {
-                    	var mediaPlaceholder = '<video src="' + data.result.path + '" controls + width="320"></video>';
+                        var mediaPlaceholder = '<video src="' + data.result.path + '" controls + width="320"></video>';
                     }
                     var html = '<figure data-id="'+ data.result.imageableId +'">' + mediaPlaceholder +
-	                    '<a class="jsRemoveSimpleLink" href="#" data-id="' + data.result.imageableId + '">' +
-	                    '<i class="fa fa-times-circle removeIcon"></i>' +
-	                    '</a></figure>';
+                    	'<a class="jsRemoveSimpleLink" href="#" data-id="' + data.result.imageableId + '">' +
+                    	'<i class="fa fa-times-circle removeIcon"></i>' +
+                    	'</a></figure>';
                     window.zoneWrapper.append(html).fadeIn();
                     if ($fileCount.length > 0) {
                         var count = parseInt($fileCount.text());

--- a/Resources/views/admin/fields/file-link-multiple.blade.php
+++ b/Resources/views/admin/fields/file-link-multiple.blade.php
@@ -84,7 +84,7 @@
         <?php if (isset($$zoneVar)): ?>
             <?php foreach ($$zoneVar as $file): ?>
                 <figure data-id="{{ $file->pivot->id }}">
-                    <img src="{{ Imagy::getThumbnail($file->path, (isset($thumbnail) ? $thumbnail : 'mediumThumb')) }}" alt="{{ $file->alt_attribute }}"/>
+                    <img src="{{ Imagy::getThumbnail($file->path, (isset($thumbnailSize) ? $thumbnailSize : 'mediumThumb')) }}" alt="{{ $file->alt_attribute }}"/>
                     <a class="jsRemoveLink" href="#" data-id="{{ $file->pivot->id }}">
                         <i class="fa fa-times-circle removeIcon"></i>
                     </a>

--- a/Resources/views/admin/fields/file-link-multiple.blade.php
+++ b/Resources/views/admin/fields/file-link-multiple.blade.php
@@ -57,10 +57,17 @@
                     'order': $('.jsThumbnailImageWrapper figure').size() + 1
                 },
                 success: function (data) {
-                    var html = '<figure data-id="' + data.result.imageableId + '"><img src="' + data.result.path + '" alt=""/>' +
-                            '<a class="jsRemoveLink" href="#" data-id="' + data.result.imageableId + '">' +
-                            '<i class="fa fa-times-circle removeIcon"></i>' +
-                            '</a></figure>';
+                	if (data.result.mediaType === 'image') {
+                        var mediaPlaceholder = '<img src="' + data.result.path + '" alt=""/>';
+	                    
+                    }
+                    else {
+                    	var mediaPlaceholder = '<video src="' + data.result.path + '" controls + width="320"></video>';
+                    }
+                    var html = '<figure data-id="'+ data.result.imageableId +'">' + mediaPlaceholder +
+	                    '<a class="jsRemoveSimpleLink" href="#" data-id="' + data.result.imageableId + '">' +
+	                    '<i class="fa fa-times-circle removeIcon"></i>' +
+	                    '</a></figure>';
                     window.zoneWrapper.append(html).fadeIn();
                     if ($fileCount.length > 0) {
                         var count = parseInt($fileCount.text());

--- a/Resources/views/admin/fields/file-link.blade.php
+++ b/Resources/views/admin/fields/file-link.blade.php
@@ -42,16 +42,15 @@
                 },
                 success: function (data) {
                 	if (data.result.mediaType === 'image') {
-                        var mediaPlaceholder = '<img src="' + data.result.path + '" alt=""/>';
-	                    
-                    }
-                    else {
-                    	var mediaPlaceholder = '<video src="' + data.result.path + '" controls + width="320"></video>';
+                    	var mediaPlaceholder = '<img src="' + data.result.path + '" alt=""/>';
+                	}
+                	else {
+                        var mediaPlaceholder = '<video src="' + data.result.path + '" controls + width="320"></video>';
                     }
                     var html = '<figure data-id="'+ data.result.imageableId +'">' + mediaPlaceholder +
-	                    '<a class="jsRemoveSimpleLink" href="#" data-id="' + data.result.imageableId + '">' +
-	                    '<i class="fa fa-times-circle removeIcon"></i>' +
-	                    '</a></figure>';
+                    	'<a class="jsRemoveSimpleLink" href="#" data-id="' + data.result.imageableId + '">' +
+                    	'<i class="fa fa-times-circle removeIcon"></i>' +
+                    	'</a></figure>';
                     window.zoneWrapper.append(html).fadeIn('slow', function() {
                         toggleButton($(this));
                     });

--- a/Resources/views/admin/fields/file-link.blade.php
+++ b/Resources/views/admin/fields/file-link.blade.php
@@ -66,7 +66,7 @@
     <figure class="jsThumbnailImageWrapper">
         <?php if (isset(${$zone}->path)): ?>
             <?php if (${$zone}->isImage()): ?>
-                <img src="{{ Imagy::getThumbnail(${$zone}->path, (isset($thumbnail) ? $thumbnail : 'mediumThumb')) }}" alt="{{ ${$zone}->alt_attribute }}"/>
+                <img src="{{ Imagy::getThumbnail(${$zone}->path, (isset($thumbnailSize) ? $thumbnailSize : 'mediumThumb')) }}" alt="{{ ${$zone}->alt_attribute }}"/>
             <?php else: ?>
                 <i class="fa fa-file" style="font-size: 50px;"></i>
             <?php endif; ?>

--- a/Resources/views/admin/fields/file-link.blade.php
+++ b/Resources/views/admin/fields/file-link.blade.php
@@ -41,10 +41,17 @@
                     'zone': window.mediaZone
                 },
                 success: function (data) {
-                    var html = '<figure data-id="'+ data.result.imageableId +'"><img src="' + data.result.path + '" alt=""/>' +
-                            '<a class="jsRemoveSimpleLink" href="#" data-id="' + data.result.imageableId + '">' +
-                            '<i class="fa fa-times-circle removeIcon"></i>' +
-                            '</a></figure>';
+                	if (data.result.mediaType === 'image') {
+                        var mediaPlaceholder = '<img src="' + data.result.path + '" alt=""/>';
+	                    
+                    }
+                    else {
+                    	var mediaPlaceholder = '<video src="' + data.result.path + '" controls + width="320"></video>';
+                    }
+                    var html = '<figure data-id="'+ data.result.imageableId +'">' + mediaPlaceholder +
+	                    '<a class="jsRemoveSimpleLink" href="#" data-id="' + data.result.imageableId + '">' +
+	                    '<i class="fa fa-times-circle removeIcon"></i>' +
+	                    '</a></figure>';
                     window.zoneWrapper.append(html).fadeIn('slow', function() {
                         toggleButton($(this));
                     });


### PR DESCRIPTION
I have modified the Media controller API in order to be able to display a preview of a video if it matches the most popular mimeTypes, fixing the issue that would render a broken 'img' (JSON was returning an empty path as well if a video was linked, because the way of getting the thumbnail via Imagy).

My version only differs on lines 74 and 78, perhaps I have not pulled from the correct way in my fork or has it been added after? Because I did not have them in the source.