### PR TITLE
Fix file-link-multiple.blade.php

### DIFF
--- a/Resources/views/admin/fields/file-link-multiple.blade.php
+++ b/Resources/views/admin/fields/file-link-multiple.blade.php
@@ -86,7 +86,7 @@
     </a>
     <div class="clearfix"></div>
     <div class="jsThumbnailImageWrapper">
-        <?php $zoneVar = "{$zone}Files"  ?>
+        <?php $zoneVar = "{$zone}"  ?>
         <?php if (isset($$zoneVar)): ?>
             <?php foreach ($$zoneVar as $file): ?>
                 <figure data-id="{{ $file->pivot->id }}">


### PR DESCRIPTION
Where  <?php $zoneVar = "{$zone}Files"  ?> is assigned, breaks the functionality to call back the images and display them.
If changed to  <?php $zoneVar = "{$zone}"  ?> , works. I hope this is useful.