### PR TITLE
Fixed bug in filename slug when file extension is uppercase

### DIFF
--- a/Helpers/FileHelper.php
+++ b/Helpers/FileHelper.php
@@ -11,7 +11,7 @@ class FileHelper
 
         $name = Str::slug($name);
 
-        return $name . $extension;
+        return $name . strtolower($extension);
     }
 
     /**
@@ -21,6 +21,6 @@ class FileHelper
      */
     private static function getExtension($name)
     {
-        return strtolower(substr($name, strrpos($name, '.')));
+        return substr($name, strrpos($name, '.'));
     }
 }

--- a/Tests/FileHelperTest.php
+++ b/Tests/FileHelperTest.php
@@ -13,4 +13,13 @@ class FileHelperTest extends BaseTestCase
 
         $this->assertEquals($expected, $name);
     }
+
+    /** @test */
+    public function it_should_return_slugged_name_when_uppercase_extension_provided()
+    {
+        $expected = 'file-name.png';
+        $name = FileHelper::slug('File Name.PNG');
+
+        $this->assertEquals($expected, $name);
+    }
 }


### PR DESCRIPTION
When uploading a file with an uppercase extension like "filename.JPG" the uploaded filename and slug end up named like "filenamejpg.jpg"

The getExtension method lowercases the extension, and the slug method can't str_replace the uppercase extension using the lowercase one.