### PR TITLE
Ck editor inline file input not refering to proper data attribute

### DIFF
--- a/Resources/views/admin/grid/ckeditor.blade.php
+++ b/Resources/views/admin/grid/ckeditor.blade.php
@@ -12,7 +12,7 @@
 
             var funcNum = getUrlParam('CKEditorFuncNum');
 
-            window.opener.CKEDITOR.tools.callFunction(funcNum, $(this).data('file'));
+            window.opener.CKEDITOR.tools.callFunction(funcNum, $(this).data('file-path'));
             window.close();
         });
     });


### PR DESCRIPTION
On the default blog post creation, update form the inline file input refers to the data-file attribute should be data-file-path