### PR TITLE
Make styling consistent

### DIFF
--- a/Resources/views/admin/fields/new-file-link-multiple.blade.php
+++ b/Resources/views/admin/fields/new-file-link-multiple.blade.php
@@ -97,7 +97,7 @@
             }
         });
 
-        $(".jsThumbnailImageWrapper").sortable({
+        $(".jsThumbnailImageWrapper").not(".jsSingleThumbnailWrapper").sortable({
             placeholder: 'ui-state-highlight',
             cursor:'move',
             helper: 'clone',

--- a/Resources/views/admin/fields/new-file-link-single.blade.php
+++ b/Resources/views/admin/fields/new-file-link-single.blade.php
@@ -1,14 +1,15 @@
 <style>
-    figure.jsThumbnailImageWrapper {
+    .jsThumbnailImageWrapper figure {
         position: relative;
         display: inline-block;
+        margin-right: 20px;
+        margin-bottom: 20px;
         background-color: #fff;
         border: 1px solid #eee;
         padding: 3px;
         border-radius: 3px;
-        margin-top: 20px;
     }
-    figure.jsThumbnailImageWrapper i.removeIcon {
+    .jsThumbnailImageWrapper i.removeIcon {
         position: absolute;
         top:-10px;
         right:-10px;
@@ -52,18 +53,20 @@
 
     <div class="clearfix"></div>
 
-    <figure class="jsThumbnailImageWrapper">
+    <div class="jsThumbnailImageWrapper jsSingleThumbnailWrapper">
         <?php if (isset(${$zone}->path)): ?>
+            <figure data-id="{{ ${$zone}->pivot->id }}>
             <?php if (${$zone}->isImage()): ?>
                 <img src="{{ Imagy::getThumbnail(${$zone}->path, (isset($thumbnailSize) ? $thumbnailSize : 'mediumThumb')) }}" alt="{{ ${$zone}->alt_attribute }}"/>
             <?php else: ?>
                 <i class="fa fa-file" style="font-size: 50px;"></i>
             <?php endif; ?>
-            <a class="jsRemoveSimpleLink" href="#" data-id="{{ ${$zone}->pivot->id }}">
-                <i class="fa fa-times-circle removeIcon"></i>
-            </a>
+                <a class="jsRemoveSimpleLink" href="#" data-id="{{ ${$zone}->pivot->id }}">
+                    <i class="fa fa-times-circle removeIcon"></i>
+                </a>
+            </figure>
         <?php endif; ?>
-    </figure>
+    </div>
 </div>
 <script>
     $( document ).ready(function() {


### PR DESCRIPTION
Make styling of single and multiple partials consistent.
In single partial we have double figure styling when media is selected also when no media selected empty figure element borders visible.

**Before empty (border dot under upload button)**
![cosmetic_before_empty](https://cloud.githubusercontent.com/assets/219556/16684300/05b6715c-450d-11e6-968f-939f3303d18c.png)

**Before (double figure styling)**
![cosmetic_before](https://cloud.githubusercontent.com/assets/219556/16684255/c12dbf72-450c-11e6-93a4-afff45af96d2.png)

**After (single figure styling wrap with div)**
![cosmetic_after](https://cloud.githubusercontent.com/assets/219556/16684260/c7728002-450c-11e6-9410-27b55c6ddf78.png)

**After empty**
![cosmetic_after_empty](https://cloud.githubusercontent.com/assets/219556/16686292/b81dd20c-4519-11e6-8d95-758bf5f12d0b.png)


