### PR TITLE
Update for laravel 5.2

### DIFF
--- a/Jobs/CreateThumbnails.php
+++ b/Jobs/CreateThumbnails.php
@@ -3,13 +3,12 @@
 namespace Modules\Media\Jobs;
 
 use App\Jobs\Job;
-use Illuminate\Contracts\Bus\SelfHandling;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Modules\Media\ValueObjects\MediaPath;
 
-class CreateThumbnails extends Job implements SelfHandling, ShouldQueue
+class CreateThumbnails extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
 

--- a/Jobs/RebuildThumbnails.php
+++ b/Jobs/RebuildThumbnails.php
@@ -3,13 +3,12 @@
 namespace Modules\Media\Jobs;
 
 use App\Jobs\Job;
-use Illuminate\Contracts\Bus\SelfHandling;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
-class RebuildThumbnails extends Job implements SelfHandling, ShouldQueue
+class RebuildThumbnails extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
 


### PR DESCRIPTION
Removed: 
_SelfHandling as per official laravel [5.1 -> 5.2 guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0):_
_You no longer need to implement the SelfHandling contract on your jobs / commands. All jobs are now self-handling by default, so you can remove this interface from your classes._

Fixed:
```
Argument 1 passed to Modules\Media\Jobs\RebuildThumbnails::__construct() must be an instance of Illuminate\Database\Eloquent\Collection, i  
  nstance of Illuminate\Support\Collection given
```
Must been a typo import (different collection) :)