### PR TITLE
Quality flag

### DIFF
--- a/Image/Imagy.php
+++ b/Image/Imagy.php
@@ -166,7 +166,7 @@ class Imagy
         foreach ($this->manager->find($thumbnail) as $manipulation => $options) {
             $image = $this->imageFactory->make($manipulation)->handle($image, $options);
         }
-        $image = $image->stream(pathinfo($path, PATHINFO_EXTENSION));
+        $image = $image->stream(pathinfo($path, PATHINFO_EXTENSION), array_get($options, 'quality', 90));
 
         $this->writeImage($filename, $image);
     }


### PR DESCRIPTION
Use the quality option for the stream function:

public Intervention\Image\Image stream([mixed $format, [int $quality]])

By default, we still have the default behavior (value of 90)

If you define a filter (see https://asgardcms.com/docs/v1/media-module/thumbnails#crop) you might set a differente quality 


```php
'crop' => [
    'width' => '100', // required 
    'height' => '200', // required 
    'x' => 0 // optional
    'y' => 0 // optional
    'quality' => 60 //optional
];
```

As mentionned in the doc it's only for JPG

> Define the quality of the encoded image optionally. Data ranging from 0 (poor quality, small file) to 100 (best quality, big file). Quality is only applied if you're encoding JPG format since PNG compression is lossless and does not affect image quality. Default: 90.