### PR TITLE
Quality for image manipulation

### DIFF
--- a/Image/Imagy.php
+++ b/Image/Imagy.php
@@ -110,7 +110,7 @@ class Imagy
             foreach ($thumbnail->filters() as $manipulation => $options) {
                 $image = $this->imageFactory->make($manipulation)->handle($image, $options);
             }
-            $image = $image->stream(pathinfo($path, PATHINFO_EXTENSION));
+            $image = $image->stream(pathinfo($path, PATHINFO_EXTENSION), array_get($thumbnail->filters(), 'quality', 90));
             $this->writeImage($filename, $image);
         }
     }

--- a/Image/Intervention/Manipulations/Quality.php
+++ b/Image/Intervention/Manipulations/Quality.php
@@ -1,0 +1,17 @@
+<?php namespace Modules\Media\Image\Intervention\Manipulations;
+
+use Modules\Media\Image\ImageHandlerInterface;
+
+class Quality implements ImageHandlerInterface
+{
+    /**
+     * Handle the image manipulation request
+     * @param  \Intervention\Image\Image $image
+     * @param  array                     $options
+     * @return \Intervention\Image\Image
+     */
+    public function handle($image, $options)
+    {
+        return $image;
+    }
+}


### PR DESCRIPTION
Use the quality option for the stream function:

public Intervention\Image\Image stream([mixed $format, [int $quality]])

By default, we still have the default behavior (value of 90 for the image quality)

If you define a filter (see https://asgardcms.com/docs/v1/media-module/thumbnails#crop) you might set a different quality 

Basic usage

```php
return [
    'smallThumb' => [
        'quality' => 50,
        'crop' => [
            'width' => '100',
            'height' => '200'
        ],
        'blur' => [
            'amount' => '15'
        ],
    ]
];
```

As mentioned in the doc it's only for JPG

> Define the quality of the encoded image optionally. Data ranging from 0 (poor quality, small file) to 100 (best quality, big file). Quality is only applied if you're encoding JPG format since PNG compression is lossless and does not affect image quality. Default: 90.