### PR TITLE
AwsS3UrlResolver now uses the correct s3 configuration instead of bei…

### DIFF
--- a/Tests/BaseUrlResolverTest.php
+++ b/Tests/BaseUrlResolverTest.php
@@ -27,4 +27,20 @@ class BaseUrlResolverTest extends MediaTestCase
 
         $this->assertEquals('https://s3-eu-west-1.amazonaws.com/testing-bucket/assets/media/my_image.png', $resolvedPath);
     }
+
+    /** @test */
+    public function it_returns_correct_aws_s3_uri_for_custom_s3_config()
+    {
+        $alternativeS3Config = 's3SomeAlternativeConfig';
+
+        config()->set('asgard.media.config.filesystem', $alternativeS3Config);
+        config()->set('filesystems.disks.' . $alternativeS3Config, config()->get('filesystems.disks.s3'));
+        config()->set('filesystems.disks.' . $alternativeS3Config . '.bucket', 'testing-bucket');
+        config()->set('filesystems.disks.' . $alternativeS3Config . '.region', 'eu-west-1');
+
+        $resolver = new BaseUrlResolver();
+        $resolvedPath = $resolver->resolve('/assets/media/my_image.png');
+
+        $this->assertEquals('https://s3-eu-west-1.amazonaws.com/testing-bucket/assets/media/my_image.png', $resolvedPath);
+    }
 }

--- a/UrlResolvers/AwsS3UrlResolver.php
+++ b/UrlResolvers/AwsS3UrlResolver.php
@@ -11,6 +11,8 @@ class AwsS3UrlResolver
      */
     public function resolve(AwsS3Adapter $adapter, $path)
     {
-        return $adapter->getClient()->getObjectUrl(config('filesystems.disks.s3.bucket'), ltrim($path, '/'));
+        $s3Config = config('asgard.media.config.filesystem', 's3');
+
+        return $adapter->getClient()->getObjectUrl(config("filesystems.disks.$s3Config.bucket"), ltrim($path, '/'));
     }
 }


### PR DESCRIPTION
…ng hardcoded to 's3', which failed it you weren't using the name 's3'.

If you have multiple s3 accounts, all defined in config/filesystems.php, configuring the media module's config asgard.media.config.filesystem to be anything other than "s3" for an s3 type filesystem, the url resolver fails.

Eg snippet from config/filesystems.php

```
        's3docs' => [
            'driver' => 's3',
            'key'    => env('S3_DOCS_KEY'),
            'secret' => env('S3_DOCS_SECRET'),
            'region' => env('S3_DOCS_REGION'),
            'bucket' => env('S3_DOCS_BUCKET'),
        ],
        's3images' => [
            'driver' => 's3',
            'key'    => env('S3_IMGS_KEY'),
            'secret' => env('S3_IMGS_SECRET'),
            'region' => env('S3_IMGS_REGION'),
            'bucket' => env('S3_IMGS_BUCKET'),
        ],
```
